### PR TITLE
Add username to GitHub Provider

### DIFF
--- a/packages/astro-auth-providers/src/providers/GithubProvider.ts
+++ b/packages/astro-auth-providers/src/providers/GithubProvider.ts
@@ -14,6 +14,7 @@ const GithubProvider = (options: OAuthUserOptions): OAuthConfig => {
       return {
         id: profile.id.toString(),
         name: profile.name || profile.login,
+        login: profile.login,
         email: profile.email,
         image: profile.avatar_url,
       };


### PR DESCRIPTION
Hi! I'm using Astro Auth in a project. It's awesome! But I'm missing the username when returning the user. :) Hope it works for you!